### PR TITLE
Align server with ChatGPT connector spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,28 @@ This is a Model Context Protocol (MCP) server that provides comprehensive financ
 
 ## MCP Tools
 
-The server exposes the following tools through the Model Context Protocol:
-
-### Stock Information
-
-| Tool | Description |
-|------|-------------|
-| `search` | Search Yahoo Finance for ticker symbols and related news |
-| `get_historical_stock_prices` | Get historical OHLCV data for a stock with customizable period and interval |
-| `get_stock_info` | Get comprehensive stock data including price, metrics, and company details |
-| `get_yahoo_finance_news` | Get latest news articles for a stock |
-| `get_stock_actions` | Get stock dividends and splits history |
-
-### Financial Statements
+To comply with the ChatGPT connector restrictions documented in `restrictions.md`,
+the server now exposes only the required `search` and `fetch` tools. Everything
+that previously lived behind individual endpoints is bundled into the metadata
+returned by `fetch`.
 
 | Tool | Description |
 |------|-------------|
-| `get_financial_statement` | Get income statement, balance sheet, or cash flow statement (annual/quarterly) |
-| `get_holder_info` | Get major holders, institutional holders, mutual funds, or insider transactions |
+| `search` | Search Yahoo Finance for ticker symbols or company names and return results whose IDs follow the `ticker:<SYMBOL>:summary` pattern. |
+| `fetch` | Retrieve the resource identified by a search result. The response contains a natural-language summary plus structured metadata covering price history, financial statements, holders, corporate actions, news headlines, and analyst recommendations. |
 
-### Options Data
+`fetch` responses expose a `metadata` object with the following sections so that
+agents can reproduce the functionality of the legacy tools:
 
-| Tool | Description |
-|------|-------------|
-| `get_option_expiration_dates` | Get available options expiration dates |
-| `get_option_chain` | Get options chain for a specific expiration date and type (calls/puts) |
-
-### Analyst Information
-
-| Tool | Description |
-|------|-------------|
-| `get_recommendations` | Get analyst recommendations or upgrades/downgrades history |
+- `info`: The raw Yahoo Finance company information dictionary.
+- `history`: Recent OHLCV price history (default one month of daily bars).
+- `financialStatements`: Annual and quarterly income statement, balance sheet,
+  and cash flow statement data.
+- `holders`: Major, institutional, mutual fund, and insider ownership data.
+- `actions`: Dividend and split history.
+- `news`: Latest Yahoo Finance headlines for the symbol.
+- `recommendations`: Analyst recommendation history plus filtered upgrades and
+  downgrades from the last twelve months.
 
 ## Real-World Use Cases
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,36 +14,23 @@
 
 ## MCP 工具
 
-服务器通过模型上下文协议提供以下工具：
-
-### 股票信息
-
-| 工具 | 描述 |
-|------|-------------|
-| `get_historical_stock_prices` | 获取股票的历史 OHLCV 数据，可自定义时间段和间隔 |
-| `get_stock_info` | 获取全面的股票数据，包括价格、指标和公司详情 |
-| `get_yahoo_finance_news` | 获取股票的最新新闻文章 |
-| `get_stock_actions` | 获取股票分红和拆股历史 |
-
-### 财务报表
+为了遵守 `restrictions.md` 中记录的 ChatGPT 连接器规范，服务器现在只暴露必需的
+`search` 和 `fetch` 两个工具，其余功能通过 `fetch` 返回的 `metadata` 提供。
 
 | 工具 | 描述 |
 |------|-------------|
-| `get_financial_statement` | 获取利润表、资产负债表或现金流量表（年度/季度） |
-| `get_holder_info` | 获取主要股东、机构股东、共同基金或内幕交易信息 |
+| `search` | 在 Yahoo Finance 中搜索股票代码或公司名称，返回 `ticker:<股票代码>:summary` 形式的 ID。 |
+| `fetch` | 根据搜索结果的 ID 获取详细数据，包含自然语言摘要和结构化元数据（价格历史、财务报表、持有人、公司行动、新闻以及分析师推荐等）。 |
 
-### 期权数据
+`fetch` 返回的 `metadata` 包含以下部分，用于覆盖旧工具的功能：
 
-| 工具 | 描述 |
-|------|-------------|
-| `get_option_expiration_dates` | 获取可用的期权到期日期 |
-| `get_option_chain` | 获取特定到期日期和类型（看涨/看跌）的期权链 |
-
-### 分析师信息
-
-| 工具 | 描述 |
-|------|-------------|
-| `get_recommendations` | 获取分析师推荐或评级变更历史 |
+- `info`: Yahoo Finance 的原始公司信息字典。
+- `history`: 最近一个月的日线 OHLCV 价格历史。
+- `financialStatements`: 年度与季度的利润表、资产负债表和现金流量表。
+- `holders`: 主要、机构、共同基金和内幕持有人数据。
+- `actions`: 分红与拆股历史。
+- `news`: 该股票的最新 Yahoo Finance 新闻。
+- `recommendations`: 分析师推荐历史以及最近 12 个月的评级上调和下调。
 
 ## 实际应用场景
 


### PR DESCRIPTION
## Summary
- replace the multi-tool interface with a ChatGPT connector compatible search/fetch workflow that emits `ticker:<SYMBOL>:summary` IDs
- add helper utilities to collect and sanitize Yahoo Finance datasets so fetch responses bundle price history, financials, holders, actions, news, and recommendations
- document the new workflow and metadata contract in both the English and Chinese READMEs

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_b_68cc152b1f2c832d98a39d86221a301c